### PR TITLE
Call fsync properly

### DIFF
--- a/core/lib/trainer.py
+++ b/core/lib/trainer.py
@@ -263,17 +263,10 @@ class Trainer:
     train_writer_fd = valid_writer_fd = None
     if os.path.exists(f'/proc/{pid}/fd'):
       for fd in os.listdir(f'/proc/{pid}/fd'):
-        print('fd')
-        print(fd)
-        print(os.path.realpath(f'/proc/{pid}/fd/{fd}'))
-        print()
         if train_dir in os.path.realpath(f'/proc/{pid}/fd/{fd}'):
           train_writer_fd = int(fd)
         if valid_dir in os.path.realpath(f'/proc/{pid}/fd/{fd}'):
           valid_writer_fd = int(fd)
-    print('writer_fds')
-    print(train_writer_fd)
-    print(valid_writer_fd)
 
     train_writer.hparams(config.to_dict())
     train_writer.flush()


### PR DESCRIPTION
Bug fix: We were incorrectly identifying the file descriptors (as None) and hence not calling fsync when trying to flush the summary writers. This PR fixes that.