### PR TITLE
Use macro F1-score instead of micro F1-score.

### DIFF
--- a/core/lib/metrics.py
+++ b/core/lib/metrics.py
@@ -27,9 +27,8 @@ def evaluate(targets, predictions, num_classes, eval_metric_names):
     results[EvaluationMetric.ACCURACY.value] = (
         jnp.sum(predictions == targets) / jnp.sum(jnp.ones_like(targets)))
   if EvaluationMetric.F1_SCORE.value in eval_metric_names:
-    # TODO(dbieber): Support macro f1.
     results[EvaluationMetric.F1_SCORE.value] = metrics.f1_score(
-        targets, predictions, average='micro')
+        targets, predictions, average='macro')
   if EvaluationMetric.CONFUSION_MATRIX.value in eval_metric_names:
     results[EvaluationMetric.CONFUSION_MATRIX.value] = metrics.confusion_matrix(
         targets,


### PR DESCRIPTION
## Overview

Micro F1-score (globally counting metrics) is equivalent to accuracy.

[Reference:](https://towardsdatascience.com/multi-class-metrics-made-simple-part-ii-the-f1-score-ebe8b2c2ca1)
```
micro_f1 = micro_precision = micro_recall = accuracy
```

Since we already compute accuracy as a metric, change F1-score to "macro"
(per-class unweighted averaging) instead.

## Example

For fun, a small test program using real target and predictions values from the IPA-GNN model:
```python
import jax
import jax.numpy as jnp
from sklearn import metrics

predictions = jnp.array(
[ 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 16,  1,  1,
  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 16,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 16,  1,  1,  1,  1,  1, 16,  1,
  1,  1,  1,  1,  1,  1,  1,  1,  1, 16,  1,  1,  1,  1,  1,  1, 16,  1,  1,  1,  1,  1,  1,  1,
  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
  1,  1,  1,  1,  1,  1, 16,  1,])

targets = jnp.array(
[ 5,  1, 25,  1, 16, 26,  3, 25,  1,  3, 16,  1,  1,  1,  1, 16,  5,  1, 16,  1,  3, 16,  1, 11,
  1,  1,  3,  1,  9,  1,  1,  1,  9, 16,  1,  1,  1, 27,  1,  1,  1, 16,  5, 25,  1,  1,  1,  1,
 16,  1, 27,  3,  1,  1,  1,  3,  1,  1,  1, 27,  1, 16, 25, 27,  1,  1, 27, 27, 27,  1,  1,  1,
  9,  1,  1, 16,  1, 16, 26, 16,  1,  1, 16,  1, 11,  1,  7, 25,  1,  1, 25,  1, 27,  7,  1, 27,
  5, 16, 25, 25,  1, 25,  1, 11,  1,  3, 27,  1, 27, 27,  1,  1, 25,  1, 25,  1,  3,  1,  1, 16,
  1, 16, 27,  1,  7,  1,  1,  1,])

# Accuracy

def accuracy(targets, predictions):
  return jnp.sum(predictions == targets) / jnp.sum(jnp.ones_like(targets))

# F1-score

def f1_scores(targets, predictions):
  return {
    average: metrics.f1_score(targets, predictions, average=average)
    for average in ['micro', 'macro', 'weighted']
  }

print('accuracy')
print(accuracy(targets, predictions))
print('f1_scores')
print(f1_scores(targets, predictions))
```
```console
$ python3 f1_score.py
accuracy
0.46875
f1_scores
{'micro': 0.46875, 'macro': 0.07213651238896682, 'weighted': 0.3330301834969612}
```

---

Builds on #35, all changes in this PR contained in its last commit. ~Rebase after #35 is merged.~ Rebased.