### PR TITLE
Clarify "last minibatch accuracy" in evaluation logging.

### DIFF
--- a/core/lib/trainer.py
+++ b/core/lib/trainer.py
@@ -322,8 +322,8 @@ Predictions:
 {predictions}
 Targets:
 {targets}
-Batch Accuracy: {100 * batch_accuracy:02.1f}
-Train Accuracy: {train_accuracy_str}""")
+Train Accuracy: {train_accuracy_str}
+Last Minibatch Accuracy: {100 * batch_accuracy:02.1f}""")
 
         # Evaluate on validation dataset.
         valid_loss, valid_metrics, num_examples = self.run_eval(


### PR DESCRIPTION
Previously, last minibatch accuracy was displayed as `Batch Accuracy`.
Now, it is displayed as `Last Minibatch Accuracy`, which is clearer.

---

This is a minor change, I don't feel strongly – also open to suggestions.