### PR TITLE
Create instruction pointer intensity plots.

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -9,8 +9,8 @@ Config = ml_collections.ConfigDict
 class EvaluationMetric(enum.Enum):
   """Evaluation metric kinds."""
   ACCURACY = 'accuracy'
-  F1_SCORE = 'f1-score'
-  CONFUSION_MATRIX = 'confusion-matrix'
+  F1_SCORE = 'f1_score'
+  CONFUSION_MATRIX = 'confusion_matrix'
 
   @staticmethod
   def all_metric_names() -> Tuple[str]:
@@ -65,6 +65,7 @@ def default_config():
   config.eval_subsample = 1.0
   config.eval_max_batches = 30
 
+  # Logging
   config.printoptions_threshold = 256
 
   config.early_stopping_on = False

--- a/core/models/ipagnn.py
+++ b/core/models/ipagnn.py
@@ -90,4 +90,4 @@ class IPAGNN(nn.Module):
     else:
       logits = nn.Dense(features=num_classes)(exit_node_embeddings)
     # logits.shape: batch_size, num_classes
-    return logits
+    return logits, ipagnn_output

--- a/core/models/mlp.py
+++ b/core/models/mlp.py
@@ -27,4 +27,4 @@ class MlpModel(nn.Module):
     x = nn.relu(x)
     x = nn.Dense(features=self.info.num_classes)(x)
     # x.shape: batch_size, num_classes
-    return x
+    return x, None

--- a/core/models/transformer.py
+++ b/core/models/transformer.py
@@ -53,4 +53,4 @@ class Transformer(nn.Module):
     # x.shape: batch_size, hidden_size
     x = nn.Dense(features=self.info.num_classes)(x)
     # x.shape: batch_size, num_classes
-    return x
+    return x, None

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ DEPENDENCIES = [
     'flax',
     'gast',
     'google-cloud-storage',
+    'imageio',
     'ipython',
     'jax>=0.2.7',
     'jaxlib>=0.1.69',


### PR DESCRIPTION
Create instruction pointer intensity plots.

Main changes:
- Make `IPAGNN` model return auxiliary info in addition to logits.
  - This involves propagating `aux` dictionaries through `IPAGNNLayer` and
    `IPAGNNModule`.
  - This also involves changing non-`IPAGNN` models (e.g. `Transformer`) to return
    `logits, None` for a consistent type signature.
- Use auxiliary info to plot IPAGNN instruction pointers.
  - Instruction pointers are plotted as `node_index` (y-axis) by `timestep` (x-axis).
  - A batch of instruction pointers are logged to TensorBoard.

Other changes:
- Rename `core/lib/evaluation.py` to `core/lib/metrics.py`.

Next steps:
- Check if IPAGNN returning `aux` dictionaries is too expensive.
- Log example code in TensorBoard alongside instruction pointer plots.
- Enable generating instruction pointer plots from model checkpoint for `n` examples.

Code adapted from notebook by @dbieber.

---

Example instruction pointer intensity plots, early in training:

```console
$ python3 -m scripts.runner --dataset_path=datasets/codenet/f=0.01 --config.eval_subsample=1 --config.model_class=IPAGNN --config.raise_in_ipagnn=True --config.eval_freq=10
```

<img width="1194" alt="Screen Shot 2021-09-24 at 11 40 47 AM" src="https://user-images.githubusercontent.com/5590046/134725380-2f97a57f-ed4b-4599-8f3a-3bd5b900e090.png">
