### PR TITLE
Save top checkpoints according to the primary validation metric during training

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -1,9 +1,10 @@
 from typing import List, Optional, Text, Tuple
 
 import ml_collections
-from core.lib.metrics import all_metric_names
+from core.lib import metrics
 
 Config = ml_collections.ConfigDict
+EvaluationMetric = metrics.EvaluationMetric
 
 
 def default_config():
@@ -57,7 +58,9 @@ def default_config():
   # Runner configs
   config.eval_freq = 10000
   config.save_freq = 5000
-  config.eval_metric_names: Tuple[str] = all_metric_names()
+  config.eval_primary_metric_scale: int = 1  # 1 or -1
+  config.eval_primary_metric_name: str = EvaluationMetric.ACCURACY.value
+  config.eval_metric_names: Tuple[str] = metrics.all_metric_names()
   config.eval_subsample = 1.0
   config.eval_max_batches = 30
 

--- a/core/data/codenet_paths.py
+++ b/core/data/codenet_paths.py
@@ -100,6 +100,10 @@ def make_checkpoints_path(run_dir):
   return os.path.join(run_dir, 'checkpoints')
 
 
+def make_top_checkpoints_path(run_dir):
+  return os.path.join(run_dir, 'top-checkpoints')
+
+
 def make_log_dir(run_dir, split='train'):
   return os.path.join(run_dir, split)
 


### PR DESCRIPTION
This PR introduces a new checkpoint directory that saves the top performing checkpoints, not the most recent checkpoints.
We continue to save the 3 most recent checkpoints in the original checkpoint directory.