### PR TITLE
Enable dry-run sweeps.

### DIFF
--- a/core/distributed/sweep.py
+++ b/core/distributed/sweep.py
@@ -202,7 +202,7 @@ def main(experiment_id=None, study_id=None, dataset_path=None, skip_create=False
   # overrides = {
   #     'config.raise_in_ipagnn': False,
   # }
-  # run_sweep(n, offset, experiment_id, study_id, 'IN', 'IPAGNN', overrides, dataset_path, skip_create, dry_run, dry_run)
+  # run_sweep(n, offset, experiment_id, study_id, 'IN', 'IPAGNN', overrides, dataset_path, skip_create, dry_run)
 
   # # Exception IPA-GNN
   # offset = 10


### PR DESCRIPTION
A dry-run sweep generates the commands for the sweep without running them. This is useful for resuming old runs on different machines than they were originally run on, or for resuming just a subset of old runs.