### PR TITLE
Add links to license for datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The pre-generated datasets are available at `gs://python-runtime-errors/datasets
 
 ### Dataset License
 
-The Python Runtime Errors dataset is licensed under the [Community Data License Agreement - Permissive - Version 2.0](https://storage.googleapis.com/python-runtime-errors/datasets/project-codenet/LICENSE).
+The Python Runtime Errors dataset is made available under the [Community Data License Agreement - Permissive - Version 2.0](https://storage.googleapis.com/python-runtime-errors/datasets/project-codenet/LICENSE).
 
 ## Training
 


### PR DESCRIPTION
The license file for the datasets isn't readily discoverable, so we add to the readme direct links to the license.